### PR TITLE
Fixing Vert.x download URL

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -37,7 +37,7 @@ if [ -d "$CACHE_DIR/.vertx" ]; then
   echo "done"
 fi
 
-VERTX_URL="http://vertx.io/downloads/vert.x-1.3.1.final.tar.gz"
+VERTX_URL="http://vert-x.github.io/vertx-downloads/downloads/vert.x-1.3.1.final.tar.gz"
 
 if [ ! -d "$BUILD_DIR/.vertx" ]; then
   echo -n "-----> Installing Vert.x 1.3.1.final build (to .vertx)....."


### PR DESCRIPTION
The URL set in the `bin/compile` is http://vertx.io/downloads/vert.x-1.3.1.final.tar.gz. This page does not exist anymore (I get a 404). I just update to a working URL based on the official Vert.x download page http://vertx.io/downloads.html
